### PR TITLE
SLING-11831 - Allow setting job properties for custom job state

### DIFF
--- a/src/main/java/org/apache/sling/event/jobs/consumer/JobExecutionContext.java
+++ b/src/main/java/org/apache/sling/event/jobs/consumer/JobExecutionContext.java
@@ -86,6 +86,13 @@ public interface JobExecutionContext {
     void updateProgress(long eta);
 
     /**
+     * Sets a property on the job. This property can be retrieved using {@link org.apache.sling.event.jobs.Job#getProperty(String)}.
+     * @param name The property name
+     * @param value The property value
+     */
+    void setProperty(String name, Object value);
+
+    /**
      * Log a message.
      * A job consumer can use this method during job processing to add additional information
      * about the current state of job processing.

--- a/src/main/java/org/apache/sling/event/jobs/consumer/package-info.java
+++ b/src/main/java/org/apache/sling/event/jobs/consumer/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("1.2.1")
+@org.osgi.annotation.versioning.Version("1.3.0")
 package org.apache.sling.event.jobs.consumer;
 
 


### PR DESCRIPTION
Add setProperty to the JobExecutionContext for adding custom properties.